### PR TITLE
CC-26448 Added security blocker functionality for merchant user emails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,13 @@
         "spryker/kernel": "^3.30.0",
         "spryker/locale": "^3.2.0",
         "spryker/merchant-user": "^1.2.0",
+        "spryker/security-blocker": "^1.2.0",
         "spryker/symfony": "^3.0.0",
         "spryker/transfer": "^3.27.0",
         "spryker/translator": "^1.1.0",
         "spryker/user-locale": "^1.0.0",
         "spryker/user-merchant-portal-gui-extension": "^1.0.0",
-        "spryker/zed-ui": "^1.6.0"
+        "spryker/zed-ui": "^1.8.0"
     },
     "require-dev": {
         "spryker/code-sniffer": "*",

--- a/data/translation/Zed/de_DE.csv
+++ b/data/translation/Zed/de_DE.csv
@@ -24,3 +24,4 @@ Password,Passwort
 "Success! The Password is updated.","Das Passwort wurde erfolgreich geändert."
 "Success! The Email is updated.","Die E-Mail wurde erfolgreich geändert."
 "The value cannot be empty","Dies ist ein Pflichtfeld"
+"Email changing has been blocked due to too many attempts.","E-Mail-Änderung wurde aufgrund zu vieler Versuche blockiert."

--- a/data/translation/Zed/en_US.csv
+++ b/data/translation/Zed/en_US.csv
@@ -24,3 +24,4 @@ Password,Password
 "Success! The Password is updated.","Success! The Password is updated."
 "Success! The Email is updated.","Success! The Email is updated."
 "The value cannot be empty","The value cannot be empty"
+"Email changing has been blocked due to too many attempts.","Email changing has been blocked due to too many attempts."

--- a/src/Spryker/Shared/UserMerchantPortalGui/Transfer/user_merchant_portal_gui.transfer.xml
+++ b/src/Spryker/Shared/UserMerchantPortalGui/Transfer/user_merchant_portal_gui.transfer.xml
@@ -48,4 +48,14 @@
         <property name="users" type="User[]" singular="user"/>
     </transfer>
 
+    <transfer name="SecurityCheckAuthContext">
+        <property name="type" type="string"/>
+        <property name="ip" type="string"/>
+        <property name="account" type="string"/>
+    </transfer>
+
+    <transfer name="SecurityCheckAuthResponse">
+        <property name="isBlocked" type="bool"/>
+    </transfer>
+
 </transfers>

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/Controller/ChangeEmailController.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/Controller/ChangeEmailController.php
@@ -75,14 +75,18 @@ class ChangeEmailController extends AbstractController
             return new JsonResponse($responseData);
         }
 
+        $userMerchantPortalGuiConfig = $this->getFactory()->getConfig();
         $merchantUserTransfer = $this->getFactory()->getMerchantUserFacade()->getCurrentMerchantUser();
         $changeEmailFormData = $changeEmailForm->getData();
 
-        if ($merchantUserTransfer->getUserOrFail()->getUsernameOrFail() !== $changeEmailFormData[ChangeEmailForm::FIELD_EMAIL]) {
+        if (
+            $userMerchantPortalGuiConfig->isSecurityBlockerForMerchantUserEmailChangingEnabled() &&
+            $merchantUserTransfer->getUserOrFail()->getUsernameOrFail() !== $changeEmailFormData[ChangeEmailForm::FIELD_EMAIL]
+        ) {
             $securityCheckAuthContextTransfer = (new SecurityCheckAuthContextTransfer())
                 ->setIp($request->getClientIp())
                 ->setAccount(static::SECURITY_BLOCKER_IDENTIFIER)
-                ->setType($this->getFactory()->getConfig()->getSecurityBlockerMerchantPortalUserEntityType());
+                ->setType($userMerchantPortalGuiConfig->getSecurityBlockerMerchantPortalUserEntityType());
 
             $this->getFactory()->getSecurityBlockerClient()->incrementLoginAttemptCount($securityCheckAuthContextTransfer);
         }

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/Controller/ChangeEmailController.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/Controller/ChangeEmailController.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Zed\UserMerchantPortalGui\Communication\Controller;
 
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
 use Spryker\Zed\Kernel\Communication\Controller\AbstractController;
 use Spryker\Zed\UserMerchantPortalGui\Communication\Form\ChangeEmailForm;
 use Symfony\Component\Form\FormInterface;
@@ -36,15 +37,30 @@ class ChangeEmailController extends AbstractController
     protected const RESPONSE_NOTIFICATION_MESSAGE_ERROR = 'Please resolve all errors.';
 
     /**
+     * @var string
+     */
+    protected const ERROR_MESSAGE_EMAIL_CHANGING_BLOCKED = 'Email changing has been blocked due to too many attempts.';
+
+    /**
+     * @var string
+     */
+    protected const SECURITY_BLOCKER_IDENTIFIER = 'email-change';
+
+    /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     public function indexAction(Request $request): JsonResponse
     {
+        $isEmailChangingBlocked = $this->isEmailChangingBlocked($request);
+        $changeEmailFormDataProvider = $this->getFactory()->createChangeEmailFormDataProvider();
+
         $changeEmailForm = $this->getFactory()
-            ->createChangeEmailForm($this->getFactory()->createChangeEmailFormDataProvider()->getData())
-            ->handleRequest($request);
+            ->createChangeEmailForm(
+                $changeEmailFormDataProvider->getData(),
+                $changeEmailFormDataProvider->getOptions(!$isEmailChangingBlocked),
+            )->handleRequest($request);
 
         $responseData = [
             'form' => $this->renderView(
@@ -56,6 +72,36 @@ class ChangeEmailController extends AbstractController
         ];
 
         if (!$changeEmailForm->isSubmitted()) {
+            return new JsonResponse($responseData);
+        }
+
+        $merchantUserTransfer = $this->getFactory()->getMerchantUserFacade()->getCurrentMerchantUser();
+        $changeEmailFormData = $changeEmailForm->getData();
+
+        if ($merchantUserTransfer->getUserOrFail()->getUsernameOrFail() !== $changeEmailFormData[ChangeEmailForm::FIELD_EMAIL]) {
+            $securityCheckAuthContextTransfer = (new SecurityCheckAuthContextTransfer())
+                ->setIp($request->getClientIp())
+                ->setAccount(static::SECURITY_BLOCKER_IDENTIFIER)
+                ->setType($this->getFactory()->getConfig()->getSecurityBlockerMerchantPortalUserEntityType());
+
+            $this->getFactory()->getSecurityBlockerClient()->incrementLoginAttemptCount($securityCheckAuthContextTransfer);
+        }
+
+        if ($isEmailChangingBlocked) {
+            $userMerchantPortalGuiFactory = $this->getFactory();
+
+            $zedUiFormResponseTransfer = $userMerchantPortalGuiFactory
+                ->getZedUiFactory()
+                ->createZedUiFormResponseBuilder()
+                ->addErrorNotification(
+                    $userMerchantPortalGuiFactory
+                        ->getTranslatorFacade()
+                        ->trans(static::ERROR_MESSAGE_EMAIL_CHANGING_BLOCKED),
+                )
+                ->createResponse();
+
+            $responseData = array_merge($responseData, $zedUiFormResponseTransfer->toArray());
+
             return new JsonResponse($responseData);
         }
 
@@ -115,5 +161,30 @@ class ChangeEmailController extends AbstractController
         $responseData = array_merge($responseData, $zedUiFormResponseTransfer->toArray());
 
         return new JsonResponse($responseData);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return bool
+     */
+    protected function isEmailChangingBlocked(Request $request): bool
+    {
+        $userMerchantPortalGuiConfig = $this->getFactory()->getConfig();
+
+        if (!$userMerchantPortalGuiConfig->isSecurityBlockerForMerchantUserEmailChangingEnabled()) {
+            return false;
+        }
+
+        $securityCheckAuthContextTransfer = (new SecurityCheckAuthContextTransfer())
+            ->setIp($request->getClientIp())
+            ->setAccount(static::SECURITY_BLOCKER_IDENTIFIER)
+            ->setType($userMerchantPortalGuiConfig->getSecurityBlockerMerchantPortalUserEntityType());
+
+        return $this
+            ->getFactory()
+            ->getSecurityBlockerClient()
+            ->isAccountBlocked($securityCheckAuthContextTransfer)
+            ->getIsBlockedOrFail();
     }
 }

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/ChangePasswordForm.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/ChangePasswordForm.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * @method \Spryker\Zed\UserMerchantPortalGui\Communication\UserMerchantPortalGuiCommunicationFactory getFactory()
+ * @method \Spryker\Zed\UserMerchantPortalGui\UserMerchantPortalGuiConfig getConfig()
  */
 class ChangePasswordForm extends AbstractType
 {

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/DataProvider/ChangeEmailFormDataProvider.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/DataProvider/ChangeEmailFormDataProvider.php
@@ -35,4 +35,16 @@ class ChangeEmailFormDataProvider
             ChangeEmailForm::KEY_ID_USER => $this->merchantUserFacade->getCurrentMerchantUser()->getIdUserOrFail(),
         ];
     }
+
+    /**
+     * @param bool $isEmailUniquenessValidationEnabled
+     *
+     * @return array<string, mixed>
+     */
+    public function getOptions(bool $isEmailUniquenessValidationEnabled = true): array
+    {
+        return [
+            ChangeEmailForm::OPTION_IS_EMAIL_UNIQUENESS_VALIDATION_ENABLED => $isEmailUniquenessValidationEnabled,
+        ];
+    }
 }

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/DataProvider/MerchantAccountFormDataProvider.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/DataProvider/MerchantAccountFormDataProvider.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Zed\UserMerchantPortalGui\Communication\Form\DataProvider;
 
+use Generated\Shared\Transfer\LocaleConditionsTransfer;
+use Generated\Shared\Transfer\LocaleCriteriaTransfer;
 use Spryker\Zed\UserMerchantPortalGui\Communication\Form\MerchantAccountForm;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToLocaleFacadeInterface;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToMerchantUserFacadeInterface;
@@ -36,14 +38,17 @@ class MerchantAccountFormDataProvider implements MerchantAccountFormDataProvider
     }
 
     /**
+     * @param bool $isEmailUniquenessValidationEnabled
+     *
      * @return array<mixed>
      */
-    public function getOptions(): array
+    public function getOptions(bool $isEmailUniquenessValidationEnabled = true): array
     {
         return [
             MerchantAccountForm::OPTIONS_LOCALE => array_flip(
                 $this->localeFacade->getAvailableLocales(),
             ),
+            MerchantAccountForm::OPTION_IS_EMAIL_UNIQUENESS_VALIDATION_ENABLED => $isEmailUniquenessValidationEnabled,
         ];
     }
 

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/DataProvider/MerchantAccountFormDataProviderInterface.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/Form/DataProvider/MerchantAccountFormDataProviderInterface.php
@@ -10,9 +10,11 @@ namespace Spryker\Zed\UserMerchantPortalGui\Communication\Form\DataProvider;
 interface MerchantAccountFormDataProviderInterface
 {
     /**
+     * @param bool $isEmailUniquenessValidationEnabled
+     *
      * @return array<mixed>
      */
-    public function getOptions(): array;
+    public function getOptions(bool $isEmailUniquenessValidationEnabled = true): array;
 
     /**
      * @return array<mixed>

--- a/src/Spryker/Zed/UserMerchantPortalGui/Communication/UserMerchantPortalGuiCommunicationFactory.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Communication/UserMerchantPortalGuiCommunicationFactory.php
@@ -19,6 +19,7 @@ use Spryker\Zed\UserMerchantPortalGui\Communication\Form\DataProvider\MerchantAc
 use Spryker\Zed\UserMerchantPortalGui\Communication\Form\MerchantAccountForm;
 use Spryker\Zed\UserMerchantPortalGui\Communication\Updater\MerchantUserUpdater;
 use Spryker\Zed\UserMerchantPortalGui\Communication\Updater\MerchantUserUpdaterInterface;
+use Spryker\Zed\UserMerchantPortalGui\Dependency\Client\UserMerchantPortalGuiToSecurityBlockerClientInterface;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToLocaleFacadeInterface;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToMerchantUserFacadeInterface;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToTranslatorFacadeInterface;
@@ -86,12 +87,13 @@ class UserMerchantPortalGuiCommunicationFactory extends AbstractCommunicationFac
 
     /**
      * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
      *
      * @return \Symfony\Component\Form\FormInterface
      */
-    public function createChangeEmailForm(array $data = []): FormInterface
+    public function createChangeEmailForm(array $data = [], array $options = []): FormInterface
     {
-        return $this->getFormFactory()->create(ChangeEmailForm::class, $data);
+        return $this->getFormFactory()->create(ChangeEmailForm::class, $data, $options);
     }
 
     /**
@@ -129,6 +131,14 @@ class UserMerchantPortalGuiCommunicationFactory extends AbstractCommunicationFac
     public function getMerchantUserFacade(): UserMerchantPortalGuiToMerchantUserFacadeInterface
     {
         return $this->getProvidedDependency(UserMerchantPortalGuiDependencyProvider::FACADE_MERCHANT_USER);
+    }
+
+    /**
+     * @return \Spryker\Zed\UserMerchantPortalGui\Dependency\Client\UserMerchantPortalGuiToSecurityBlockerClientInterface
+     */
+    public function getSecurityBlockerClient(): UserMerchantPortalGuiToSecurityBlockerClientInterface
+    {
+        return $this->getProvidedDependency(UserMerchantPortalGuiDependencyProvider::CLIENT_SECURITY_BLOCKER);
     }
 
     /**

--- a/src/Spryker/Zed/UserMerchantPortalGui/Dependency/Client/UserMerchantPortalGuiToSecurityBlockerClientBridge.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Dependency/Client/UserMerchantPortalGuiToSecurityBlockerClientBridge.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Spryker Marketplace License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\UserMerchantPortalGui\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+class UserMerchantPortalGuiToSecurityBlockerClientBridge implements UserMerchantPortalGuiToSecurityBlockerClientInterface
+{
+    /**
+     * @var \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface
+     */
+    protected $securityBlockerClient;
+
+    /**
+     * @param \Spryker\Client\SecurityBlocker\SecurityBlockerClientInterface $securityBlockerClient
+     */
+    public function __construct($securityBlockerClient)
+    {
+        $this->securityBlockerClient = $securityBlockerClient;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->incrementLoginAttemptCount($securityCheckAuthContextTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer
+    {
+        return $this->securityBlockerClient->isAccountBlocked($securityCheckAuthContextTransfer);
+    }
+}

--- a/src/Spryker/Zed/UserMerchantPortalGui/Dependency/Client/UserMerchantPortalGuiToSecurityBlockerClientInterface.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/Dependency/Client/UserMerchantPortalGuiToSecurityBlockerClientInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Spryker Marketplace License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\UserMerchantPortalGui\Dependency\Client;
+
+use Generated\Shared\Transfer\SecurityCheckAuthContextTransfer;
+use Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer;
+
+interface UserMerchantPortalGuiToSecurityBlockerClientInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function incrementLoginAttemptCount(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer
+     *
+     * @return \Generated\Shared\Transfer\SecurityCheckAuthResponseTransfer
+     */
+    public function isAccountBlocked(SecurityCheckAuthContextTransfer $securityCheckAuthContextTransfer): SecurityCheckAuthResponseTransfer;
+}

--- a/src/Spryker/Zed/UserMerchantPortalGui/UserMerchantPortalGuiConfig.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/UserMerchantPortalGuiConfig.php
@@ -2,7 +2,7 @@
 
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
- * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * Use of this software requires acceptance of the Spryker Marketplace License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\UserMerchantPortalGui;
@@ -17,6 +17,18 @@ class UserMerchantPortalGuiConfig extends AbstractBundleConfig
     protected const IS_EMAIL_UPDATE_PASSWORD_VERIFICATION_ENABLED = false;
 
     /**
+     * @var bool
+     */
+    protected const IS_SECURITY_BLOCKER_FOR_MERCHANT_USER_EMAIL_CHANGING_ENABLED = false;
+
+    /**
+     * @uses \Spryker\Client\SecurityBlockerMerchantPortal\SecurityBlockerMerchantPortalConfig::MERCHANT_PORTAL_USER_ENTITY_TYPE
+     *
+     * @var string
+     */
+    protected const ENTITY_TYPE_MERCHANT_PORTAL_USER = 'merchant-portal-user';
+
+    /**
      * Specification:
      * - Returns whether email update should be protected with password validation.
      *
@@ -27,5 +39,31 @@ class UserMerchantPortalGuiConfig extends AbstractBundleConfig
     public function isEmailUpdatePasswordVerificationEnabled(): bool
     {
         return static::IS_EMAIL_UPDATE_PASSWORD_VERIFICATION_ENABLED;
+    }
+
+    /**
+     * Specification:
+     * - Defines whether merchant user email change is protected by security blocker functionality.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function isSecurityBlockerForMerchantUserEmailChangingEnabled(): bool
+    {
+        return static::IS_SECURITY_BLOCKER_FOR_MERCHANT_USER_EMAIL_CHANGING_ENABLED;
+    }
+
+    /**
+     * Specification:
+     * - Returns merchant portal user entity type for security blocker functionality.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getSecurityBlockerMerchantPortalUserEntityType(): string
+    {
+        return static::ENTITY_TYPE_MERCHANT_PORTAL_USER;
     }
 }

--- a/src/Spryker/Zed/UserMerchantPortalGui/UserMerchantPortalGuiDependencyProvider.php
+++ b/src/Spryker/Zed/UserMerchantPortalGui/UserMerchantPortalGuiDependencyProvider.php
@@ -9,10 +9,14 @@ namespace Spryker\Zed\UserMerchantPortalGui;
 
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
+use Spryker\Zed\UserMerchantPortalGui\Dependency\Client\UserMerchantPortalGuiToSecurityBlockerClientBridge;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToLocaleFacadeBridge;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToMerchantUserFacadeBridge;
 use Spryker\Zed\UserMerchantPortalGui\Dependency\Facade\UserMerchantPortalGuiToTranslatorFacadeBridge;
 
+/**
+ * @method \Spryker\Zed\UserMerchantPortalGui\UserMerchantPortalGuiConfig getConfig()
+ */
 class UserMerchantPortalGuiDependencyProvider extends AbstractBundleDependencyProvider
 {
     /**
@@ -29,6 +33,11 @@ class UserMerchantPortalGuiDependencyProvider extends AbstractBundleDependencyPr
      * @var string
      */
     public const FACADE_TRANSLATOR = 'FACADE_TRANSLATOR';
+
+    /**
+     * @var string
+     */
+    public const CLIENT_SECURITY_BLOCKER = 'CLIENT_SECURITY_BLOCKER';
 
     /**
      * @uses \Spryker\Zed\ZedUi\Communication\Plugin\Application\ZedUiApplicationPlugin::SERVICE_ZED_UI_FACTORY
@@ -54,6 +63,7 @@ class UserMerchantPortalGuiDependencyProvider extends AbstractBundleDependencyPr
         $container = $this->addLocaleFacade($container);
         $container = $this->addMerchantUserFacade($container);
         $container = $this->addTranslatorFacade($container);
+        $container = $this->addSecurityBlockerClient($container);
         $container = $this->addZedUiFactory($container);
 
         $container = $this->addMerchantUserPostChangePlugin($container);
@@ -98,6 +108,22 @@ class UserMerchantPortalGuiDependencyProvider extends AbstractBundleDependencyPr
     {
         $container->set(static::FACADE_TRANSLATOR, function (Container $container) {
             return new UserMerchantPortalGuiToTranslatorFacadeBridge($container->getLocator()->translator()->facade());
+        });
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addSecurityBlockerClient(Container $container): Container
+    {
+        $container->set(static::CLIENT_SECURITY_BLOCKER, function (Container $container) {
+            return new UserMerchantPortalGuiToSecurityBlockerClientBridge(
+                $container->getLocator()->securityBlocker()->client(),
+            );
         });
 
         return $container;


### PR DESCRIPTION
Branch: backport/1.13.0
Ticket: https://spryker.atlassian.net/browse/CC-26448
Version: 1.13.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   UserMerchantPortalGui  | minor                 |            ZedUi           |

-----------------------------------------

#### Module UserMerchantPortalGui

##### Change log

Improvements

- Adjusted `ChangeEmailController::indexAction()` so it uses security blocker functionality for merchant user email updating if it's enabled in module config.
- Adjusted `MyAccountController::indexAction()` so it uses security blocker functionality for merchant user email updating if it's enabled in module config.
- Introduced `UserMerchantPortalGuiConfig::getSecurityBlockerMerchantPortalUserEntityType()`.
- Introduced `UserMerchantPortalGuiConfig::isSecurityBlockerForMerchantUserEmailChangingEnabled()`.
- Introduced `SecurityCheckAuthContext` transfer object.
- Introduced `SecurityCheckAuthResponse` transfer object.
- Added `SecurityBlockerClientInterface` to dependencies.
- Added `SecurityBlocker` module dependency.
- Increased `ZedUi` module dependency version.
